### PR TITLE
feat: adjust biography height, rearrange Karma & Reputation, and enhance GM Manager toggle

### DIFF
--- a/public/templates/app/gm-manager-chat.hbs
+++ b/public/templates/app/gm-manager-chat.hbs
@@ -1,0 +1,1 @@
+<button class="gm-chat-button">{{title}}</button>

--- a/public/templates/app/gm-manager.hbs
+++ b/public/templates/app/gm-manager.hbs
@@ -1,6 +1,10 @@
-<div id="gm-manager" class="app window-app {{#each options.classes as |cssClass|}}{{cssClass}}{{/each}}">
+<div id="gm-manager"
+  class="app window-app {{#each options.classes as |cssClass|}}{{cssClass}}{{/each}}">
   <header class="header app-title-bar">
     <label>{{localize ANARCHY.gmManager.title}}</label>
+    <button class="gm-manager-hide-button">
+      <i class="fa-solid fa-eye-slash"></i>
+    </button>
   </header>
   {{> 'systems/anarchy/templates/app/gm-anarchy.hbs'}}
   {{> 'systems/anarchy/templates/app/gm-difficulty.hbs'}}

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -29,30 +29,33 @@ export class GMManager extends Application {
       })
     Hooks.once('ready', () => this.onReady());
     Hooks.on("renderChatLog", async (app, html, data) => {
-      const templatePath = "systems/anarchy/templates/app/gm-manager-chat.hbs"; // Adjust the path if necessary
-      const templateData = {
-        title: game.i18n.localize("ANARCHY.gmManager.title"),
-      };
-      const template = await renderTemplate(templatePath, templateData);
-      const button = $(template);
+      if (game.user.isGM) {
+        const templatePath = "systems/anarchy/templates/app/gm-manager-chat.hbs"; // Adjust the path if necessary
+        const templateData = {
+          title: game.i18n.localize("ANARCHY.gmManager.title"),
+        };
+        const template = await renderTemplate(templatePath, templateData);
+        const button = $(template);
 
-      button.css({
-        zIndex: 1000,
-        flex: "0 0 28px",
-        margin: "0 8px 4px 8px",
-        width: "calc(100% - 16px)"
-      });
+        button.css({
+          zIndex: 1000,
+          flex: "0 0 28px",
+          margin: "0 8px 4px 8px",
+          width: "calc(100% - 16px)"
+        });
 
-      button.on("click", () => {
-        if (this._element) {
-          this.close();
-        } else {
-          this.render(true);
-        }
-      });
+        button.on("click", () => {
+          if (this._element) {
+            this.close();
+          } else {
+            this.render(true);
+          }
+        });
 
-      html.append(button);
-    });
+        html.append(button);
+      }
+    }
+    );
   }
 
   onReady() {

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -2,6 +2,7 @@ import { HandleDragApplication } from "./handle-drag.js";
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
 import { GMDifficulty } from "./gm-difficulty.js";
+import "../../styles/gm-manager.scss";
 
 
 const GM_MANAGER = "gm-manager";
@@ -27,6 +28,31 @@ export class GMManager extends Application {
         }
       })
     Hooks.once('ready', () => this.onReady());
+    Hooks.on("renderChatLog", async (app, html, data) => {
+      const templatePath = "systems/anarchy/templates/app/gm-manager-chat.hbs"; // Adjust the path if necessary
+      const templateData = {
+        title: game.i18n.localize("ANARCHY.gmManager.title"),
+      };
+      const template = await renderTemplate(templatePath, templateData);
+      const button = $(template);
+
+      button.css({
+        zIndex: 1000,
+        flex: "0 0 28px",
+        margin: "0 8px 4px 8px",
+        width: "calc(100% - 16px)"
+      });
+
+      button.on("click", () => {
+        if (this._element) {
+          this.close();
+        } else {
+          this.render(true);
+        }
+      });
+
+      html.append(button);
+    });
   }
 
   onReady() {
@@ -70,11 +96,11 @@ export class GMManager extends Application {
     super.activateListeners(html);
 
     html.find('.app-title-bar').mousedown(event => this.handleDrag.onMouseDown(event));
+    html.find('.gm-manager-hide-button').mousedown(event => this.close());
 
     this.gmAnarchy.activateListeners(html);
     this.gmConvergence.activateListeners(html);
     this.gmDifficulty.activateListeners(html);
-
   }
-}
 
+}

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -30,7 +30,7 @@ export class GMManager extends Application {
     Hooks.once('ready', () => this.onReady());
     Hooks.on("renderChatLog", async (app, html, data) => {
       if (game.user.isGM) {
-        const templatePath = "systems/anarchy/templates/app/gm-manager-chat.hbs"; // Adjust the path if necessary
+        const templatePath = "systems/anarchy/templates/app/gm-manager-chat.hbs";
         const templateData = {
           title: game.i18n.localize("ANARCHY.gmManager.title"),
         };

--- a/src/styles/character-enhanced-sheet.scss
+++ b/src/styles/character-enhanced-sheet.scss
@@ -1437,6 +1437,9 @@
             .social-info {
                 display: grid;
                 grid-template-columns: 1fr 1fr;
+                @container (max-width:500px) {
+                    grid-template-columns: 1fr;
+                }
                 gap: 1rem;
 
                 .title {

--- a/src/styles/character-enhanced-sheet.scss
+++ b/src/styles/character-enhanced-sheet.scss
@@ -325,7 +325,6 @@
         .section-dispositions,
         .section-actions,
         .section-qualities,
-        .section-story,
         .section-equipments,
         .section-owned,
         .section-shadowamps {

--- a/src/styles/gm-manager.scss
+++ b/src/styles/gm-manager.scss
@@ -1,0 +1,10 @@
+#gm-manager {
+    header {
+        display:flex;
+        justify-content: space-between;
+        align-items: center;
+        button.gm-manager-hide-button {
+            width: 32px;
+        }
+    }
+}


### PR DESCRIPTION
- Remove height limit for biography
- On small popups, position Karma above Reputation for better layout
- Enable GM Manager toggle on tablets/smartphones using the TouchVTT module

![image](https://github.com/user-attachments/assets/b3a8578f-57e9-441f-b6e7-265418b119d3)
![image](https://github.com/user-attachments/assets/f20113ad-4e96-437b-82f7-dc7622b08f36)
